### PR TITLE
test: final LLM review probe on hycu_fsds

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,3 +248,5 @@ MIT License — 자세한 내용은 [LICENSE](LICENSE) 참고.
 - [Formula Student Driverless Simulator](https://github.com/FS-Driverless/Formula-Student-Driverless-Simulator)
 - [AGENTS.md](AGENTS.md) — 본 프로젝트의 상세 컨벤션 / 아키텍처
 - [docs/SUBMISSION_GUIDE.md](docs/SUBMISSION_GUIDE.md) — 대회 제출 가이드
+
+<!-- LLM final probe 1777812018 -->


### PR DESCRIPTION
Final probe after all 3 stages of fixes:
1. GITHUB__USER_TOKEN (dynaconf nested key for github.user_token)
2. OPENAI.KEY (litellm api_key path - was OPENAI_KEY single-underscore)
3. CONFIG.CUSTOM_MODEL_MAX_TOKENS=128000 (kimi/claude not in MAX_TOKENS table)

Expected: github-actions[bot] posts a Korean LLM review comment within ~90s.