### PR TITLE
chore: standardize automation workflows + dependabot config

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -25,7 +25,7 @@ concurrency:
 
 jobs:
   actionlint:
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
     timeout-minutes: 5
     steps:
       - name: Checkout

--- a/.github/workflows/branch-to-pr.yml
+++ b/.github/workflows/branch-to-pr.yml
@@ -49,7 +49,7 @@ concurrency:
 
 jobs:
   open-ready-pr:
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
     timeout-minutes: 5
     # Skip pushes from jclee-bot itself or from automated branch creation.
     if: >-

--- a/.github/workflows/ci-failure-issues.yml
+++ b/.github/workflows/ci-failure-issues.yml
@@ -54,7 +54,7 @@ concurrency:
 
 jobs:
   triage:
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
     timeout-minutes: 5
     # Trigger only on FAILURE conclusion (success → close stale below).
     # workflow_run only fires on default branch by default, which is what we want.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,7 +32,7 @@ concurrency:
 jobs:
   analyze:
     name: Analyze (Python)
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -26,7 +26,7 @@ permissions:
 jobs:
   dependabot:
     if: ${{ github.actor == 'dependabot[bot]' && github.event.pull_request.draft == false }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
     steps:
       - name: Fetch Dependabot metadata
         id: meta

--- a/.github/workflows/downstream-health-check.yml
+++ b/.github/workflows/downstream-health-check.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
     timeout-minutes: 10
     name: Check downstream workflow health
 

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -42,7 +42,7 @@ concurrency:
 
 jobs:
   scan:
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
     timeout-minutes: 10
     steps:
       - name: Checkout

--- a/.github/workflows/issue-backfill.yml
+++ b/.github/workflows/issue-backfill.yml
@@ -51,7 +51,7 @@ concurrency:
 
 jobs:
   backfill:
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
     timeout-minutes: 10
     steps:
       - name: Pick and label candidates

--- a/.github/workflows/issue-to-branch.yml
+++ b/.github/workflows/issue-to-branch.yml
@@ -30,7 +30,7 @@ concurrency:
 
 jobs:
   create-branch:
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
     timeout-minutes: 5
     # Trigger only when the label is `in-progress` OR the issue gets assigned to a human (not the bot itself).
     if: >-

--- a/.github/workflows/merged-pr-cleanup.yml
+++ b/.github/workflows/merged-pr-cleanup.yml
@@ -32,7 +32,7 @@ concurrency:
 
 jobs:
   cleanup:
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
     timeout-minutes: 5
     if: >-
       github.event_name == 'workflow_dispatch' ||

--- a/.github/workflows/pr-auto-merge.yml
+++ b/.github/workflows/pr-auto-merge.yml
@@ -35,7 +35,7 @@ concurrency:
 
 jobs:
   enable-auto-merge:
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
     timeout-minutes: 5
     # Trigger on either:
     #   1. an APPROVED review on a non-draft, non-bot PR

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -24,7 +24,7 @@ concurrency:
 jobs:
   pr_review:
     if: github.event.pull_request.draft == false && github.event.pull_request.user.login != 'dependabot[bot]'
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
     name: PR review via CLIProxyAPI
     timeout-minutes: 30
 

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -34,7 +34,7 @@ concurrency:
 
 jobs:
   bump-and-publish:
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
     timeout-minutes: 10
     steps:
       - name: Checkout (full history for tag scan)

--- a/.github/workflows/reusable-docs-sync.yml
+++ b/.github/workflows/reusable-docs-sync.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   link-check:
     if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
     timeout-minutes: 10
     steps:
       - name: Checkout
@@ -53,7 +53,7 @@ jobs:
 
   markdown-lint:
     if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
     timeout-minutes: 10
     steps:
       - name: Checkout
@@ -75,7 +75,7 @@ jobs:
             --ignore '**/pr-agent-upstream-README.md'
 
   readme-sync-check:
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
     timeout-minutes: 10
     if: github.event_name == 'pull_request'
     steps:
@@ -132,7 +132,7 @@ jobs:
             }
 
   api-docs-check:
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
     timeout-minutes: 10
     if: github.event_name == 'pull_request'
     steps:

--- a/.github/workflows/reusable-issue-management.yml
+++ b/.github/workflows/reusable-issue-management.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   stale-check:
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
     timeout-minutes: 10
     steps:
       - name: Stale Issue Detection
@@ -29,7 +29,7 @@ jobs:
           remove-stale-when-updated: true
 
   auto-label:
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
     timeout-minutes: 10
     if: github.event_name == 'issues' && github.event.action == 'opened'
     steps:
@@ -84,7 +84,7 @@ jobs:
             }
 
   stale-remove:
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
     timeout-minutes: 10
     if: github.event_name == 'issue_comment' || (github.event_name == 'issues' && contains(fromJson('["reopened", "edited"]'), github.event.action))
     steps:
@@ -107,7 +107,7 @@ jobs:
 
 
   issue-stats:
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
     timeout-minutes: 10
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     steps:

--- a/.github/workflows/reusable-pr-checks.yml
+++ b/.github/workflows/reusable-pr-checks.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   check-size:
     if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
     timeout-minutes: 10
     name: Check PR Size
     steps:
@@ -49,7 +49,7 @@ jobs:
 
   check-title:
     if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
     timeout-minutes: 10
     name: Check PR Title
     steps:
@@ -75,7 +75,7 @@ jobs:
 
   check-branch:
     if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
     timeout-minutes: 10
     name: Check Branch Name
     steps:
@@ -101,7 +101,7 @@ jobs:
 
   check-description:
     if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
     timeout-minutes: 10
     name: Check PR Description
     steps:
@@ -144,7 +144,7 @@ jobs:
 
   check-large-files:
     if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
     timeout-minutes: 10
     name: Check Large Files
     steps:
@@ -181,7 +181,7 @@ jobs:
 
   check-sensitive-files:
     if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
     timeout-minutes: 10
     name: Check Sensitive Files
     steps:

--- a/.github/workflows/security/pr-review.yml
+++ b/.github/workflows/security/pr-review.yml
@@ -17,7 +17,7 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository &&
       github.event.pull_request.user.login == 'jclee941'
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
     name: Deep security review via CLIProxyAPI
     timeout-minutes: 20
 


### PR DESCRIPTION
### **User description**
## Summary

Sync standard automation from `jclee941/.github`:

- **PR checks** (size, title, branch name, description, large files, sensitive files) - 2 enforcing + 4 advisory contexts.
- **Auto-review** via cli_proxy on every non-draft PR (Dependabot PRs are reviewed by `dependabot-auto-merge.yml` instead).
- **Dependabot auto-merge** for patch + minor + github_actions updates; majors and unknown update-types are commented for manual review.
- **CodeQL** (Python SAST), **Gitleaks** (secret scanning), **actionlint** (workflow YAML linter).
- **`.github/dependabot.yml`** schedules weekly `github-actions` + `pip` ecosystem updates. (`pip` will warn 'no manifest found' on non-Python repos; safe to ignore until Python is added.)
- **`.github/CODEOWNERS`** + **`.github/PULL_REQUEST_TEMPLATE.md`** - per-repo files (org-level CODEOWNERS does NOT propagate).
- **Issue management + docs sync** workflows.

Deployed by `scripts/deploy-to-repos.go` from `jclee941/.github`. See [AGENTS.md § GIT FLOW AUTOMATION](https://github.com/jclee941/.github/blob/master/AGENTS.md#git-flow-automation) for the inventory and policy.

## Rollout sequence (REQUIRED ORDER - do not skip)

1. **Merge this PR** — the new workflows (`gitleaks.yml`, `codeql.yml`, `actionlint.yml`) start running on subsequent PRs as **advisory** checks. They are NOT yet required.
2. **Confirm `Gitleaks / scan` is green** — open one trivial test PR (or wait for the next real PR) and verify the Gitleaks job passes. If the repo has historical leaks, `gitleaks` will fail. In that case add a `.gitleaksignore` (one fingerprint per line) or a repo-local `.gitleaks.toml` allowlist, commit it, and re-run.
3. **Apply branch protection** — only after step 2 succeeds, run from `jclee941/.github`:
   ```
   go run ./scripts/cmd/branch-protection --repos=<this-repo>
   ```
   This registers `Gitleaks / scan` as a third required status check (alongside the two existing `pr-checks` contexts). Skipping step 2 will deadlock all subsequent PRs (including Dependabot) on a missing required check.


___

### **PR Type**
Enhancement


___

### **Description**
- `github.repository_visibility` 기준 runner 동적 선택

- Private 저장소는 `self-hosted` runner 사용

- Public 저장소는 `ubuntu-latest` 유지


___

### Diagram Walkthrough


```mermaid
flowchart LR
  workflow["워크플로우 트리거"] --> check{"저장소 가시성"}
  check -- "Private" --> self["self-hosted runner"]
  check -- "Public" --> ubuntu["ubuntu-latest"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><details><summary>17 files</summary><table>
<tr>
  <td><strong>actionlint.yml</strong><dd><code>actionlint 워크플로우 `runs-on` 조건부 설정 변경</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jclee941/hycu_fsds/pull/56/files#diff-7ead7509c09411da47590f81c50314ace562cf4a25d49ecf60e926cb47589f9c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>branch-to-pr.yml</strong><dd><code>branch-to-pr 워크플로우 `runs-on` 조건부 설정 변경</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jclee941/hycu_fsds/pull/56/files#diff-64d8b403b68f90a00b5a3e12c769d2367c7cb93c439cdbf267ff142effab1416">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ci-failure-issues.yml</strong><dd><code>ci-failure-issues 워크플로우 `runs-on` 조건부 설정 변경</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jclee941/hycu_fsds/pull/56/files#diff-7e6f6ffd47cfb5fa52b303eadd7d50550a4f855045369b1c0501e751d40b32d6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>codeql.yml</strong><dd><code>codeql 워크플로우 `runs-on` 조건부 설정 변경</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jclee941/hycu_fsds/pull/56/files#diff-12783128521e452af0cfac94b99b8d250413c516ec71fe6d97dbea666ff7ba27">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>dependabot-auto-merge.yml</strong><dd><code>dependabot-auto-merge 워크플로우 `runs-on` 조건부 설정 변경</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jclee941/hycu_fsds/pull/56/files#diff-2fe48d1021006468ac63263583b5db615dd5e63a39ebff862cc4e2f06b59caa1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>downstream-health-check.yml</strong><dd><code>downstream-health-check 워크플로우 `runs-on` 조건부 설정 변경</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jclee941/hycu_fsds/pull/56/files#diff-8dccb43dc9251b3da63d521bb94bba9e6a89e3ebf562bd8459673cfbc0f17a5f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>gitleaks.yml</strong><dd><code>gitleaks 워크플로우 `runs-on` 조건부 설정 변경</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jclee941/hycu_fsds/pull/56/files#diff-2aa7a05eafb406b4c582ed3bd35f2ef3a6fadeaad31372f62a79bd7610e1e453">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>issue-backfill.yml</strong><dd><code>issue-backfill 워크플로우 `runs-on` 조건부 설정 변경</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jclee941/hycu_fsds/pull/56/files#diff-b18a0b75da9e93f433844a0e7fea161ae24ffc18c6f48190ae9e3abf875f5e35">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>issue-to-branch.yml</strong><dd><code>issue-to-branch 워크플로우 `runs-on` 조건부 설정 변경</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jclee941/hycu_fsds/pull/56/files#diff-906726cafe36fa540b22379871e0a61ff1108848c34b95f5e73a03ed16ed10da">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>merged-pr-cleanup.yml</strong><dd><code>merged-pr-cleanup 워크플로우 `runs-on` 조건부 설정 변경</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jclee941/hycu_fsds/pull/56/files#diff-aa7640f67f8a31fc8e26f95c0507a65097d8993fba884e86317798cf34ed3ba3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>pr-auto-merge.yml</strong><dd><code>pr-auto-merge 워크플로우 `runs-on` 조건부 설정 변경</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jclee941/hycu_fsds/pull/56/files#diff-61c0d56ab06ca0109392dffccd6cf28b542b40fe66cdc5db85f8b6da53e9395d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>pr-review.yml</strong><dd><code>pr-review 워크플로우 `runs-on` 조건부 설정 변경</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jclee941/hycu_fsds/pull/56/files#diff-ee9bf7bbe9abf7b72c579b32d4e5fad5de41d3ba6ee351c5d10c43e805bfc475">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>release-publish.yml</strong><dd><code>release-publish 워크플로우 `runs-on` 조건부 설정 변경</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jclee941/hycu_fsds/pull/56/files#diff-c6d47dacf31662f6791d0cf218b1d34ee0ab48348c037819431cdd40e3fc23e4">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>reusable-docs-sync.yml</strong><dd><code>reusable-docs-sync 워크플로우 4개 job `runs-on` 설정 변경</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jclee941/hycu_fsds/pull/56/files#diff-4a1f29f72a980db95bc8265ef1c75404098d95a138d2c59772083ec5259c4d2a">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>reusable-issue-management.yml</strong><dd><code>reusable-issue-management 워크플로우 4개 job `runs-on` 설정 변경</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jclee941/hycu_fsds/pull/56/files#diff-321d5a584f7c9be882556476d570355f5243ec98cb2925e63566ada047783335">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>reusable-pr-checks.yml</strong><dd><code>reusable-pr-checks 워크플로우 6개 job `runs-on` 설정 변경</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jclee941/hycu_fsds/pull/56/files#diff-c847d70b033c8a55778bee6b336f27519c76efbe8d9f7b8c67108ef006d42ee7">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>pr-review.yml</strong><dd><code>security/pr-review 워크플로우 `runs-on` 조건부 설정 변경</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jclee941/hycu_fsds/pull/56/files#diff-513ee07d16eda66667845fd2aa3415fb93158efd4109f7fe1718df8dfc3e4d7f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

