### PR TITLE
chore: standardize automation workflows + dependabot config

### DIFF
--- a/.github/workflows/downstream-health-check.yml
+++ b/.github/workflows/downstream-health-check.yml
@@ -23,6 +23,9 @@ jobs:
     steps:
       - name: Checkout repository inventory
         uses: actions/checkout@v4
+        with:
+          repository: jclee941/.github
+          path: .github-inventory
 
       - name: Check latest workflow runs across all repos
         id: health
@@ -31,26 +34,20 @@ jobs:
         run: |
           set -u
 
-          REPOS=$(ruby -ryaml -e 'puts YAML.load_file("config/repos.yaml").fetch("repositories").select { |repo| repo.fetch("automation").fetch("health_check") }.map { |repo| repo.fetch("name") }.join(" ")')
+          REPOS=$(ruby -ryaml -e 'puts YAML.load_file(".github-inventory/config/repos.yaml").fetch("repositories").select { |repo| repo.fetch("automation").fetch("health_check") }.map { |repo| repo.fetch("name") }.join(" ")')
           WORKFLOWS=("actionlint" "pr-checks" "gitleaks")
           FAILURES=()
 
           for REPO in $REPOS; do
             FULL="jclee941/$REPO"
             for WF in "${WORKFLOWS[@]}"; do
-              # Get the latest run for this workflow
-              RUN_JSON=$(gh run list -R "$FULL" -w "$WF" --limit 1 --json conclusion,headBranch,url,createdAt 2>/dev/null || true)
-              if [ -z "$RUN_JSON" ] || [ "$RUN_JSON" = "[]" ]; then
+              LATEST=$(gh run list -R "$FULL" --workflow "$WF" --limit 1 --json conclusion,status,createdAt --jq '.[0]')
+              if [ -z "$LATEST" ] || [ "$LATEST" = "[]" ]; then
                 continue
               fi
-
-              CONCLUSION=$(echo "$RUN_JSON" | jq -r '.[0].conclusion')
-              BRANCH=$(echo "$RUN_JSON" | jq -r '.[0].headBranch')
-              URL=$(echo "$RUN_JSON" | jq -r '.[0].url')
-              CREATED=$(echo "$RUN_JSON" | jq -r '.[0].createdAt')
-
-              if [ "$CONCLUSION" != "success" ] && [ "$CONCLUSION" != "null" ] && [ -n "$CONCLUSION" ]; then
-                FAILURES+=("| $REPO | $WF | $CONCLUSION | $BRANCH | [$CREATED]($URL) |")
+              CONCLUSION=$(echo "$LATEST" | jq -r '.conclusion')
+              if [ "$CONCLUSION" != "success" ] && [ "$CONCLUSION" != "" ]; then
+                FAILURES+=("- $FULL \`$WF\` → conclusion=\`$CONCLUSION\`")
               fi
             done
           done


### PR DESCRIPTION
### **User description**
## Summary

Sync standard automation from `jclee941/.github`:

- **PR checks** (size, title, branch name, description, large files, sensitive files) - 2 enforcing + 4 advisory contexts.
- **Auto-review** via cli_proxy on every non-draft PR (Dependabot PRs are reviewed by `dependabot-auto-merge.yml` instead).
- **Dependabot auto-merge** for patch + minor + github_actions updates; majors and unknown update-types are commented for manual review.
- **CodeQL** (Python SAST), **Gitleaks** (secret scanning), **actionlint** (workflow YAML linter).
- **`.github/dependabot.yml`** schedules weekly `github-actions` + `pip` ecosystem updates. (`pip` will warn 'no manifest found' on non-Python repos; safe to ignore until Python is added.)
- **`.github/CODEOWNERS`** + **`.github/PULL_REQUEST_TEMPLATE.md`** - per-repo files (org-level CODEOWNERS does NOT propagate).
- **Issue management + docs sync** workflows.

Deployed by `scripts/deploy-to-repos.go` from `jclee941/.github`. See [AGENTS.md § GIT FLOW AUTOMATION](https://github.com/jclee941/.github/blob/master/AGENTS.md#git-flow-automation) for the inventory and policy.

## Rollout sequence (REQUIRED ORDER - do not skip)

1. **Merge this PR** — the new workflows (`gitleaks.yml`, `codeql.yml`, `actionlint.yml`) start running on subsequent PRs as **advisory** checks. They are NOT yet required.
2. **Confirm `Gitleaks / scan` is green** — open one trivial test PR (or wait for the next real PR) and verify the Gitleaks job passes. If the repo has historical leaks, `gitleaks` will fail. In that case add a `.gitleaksignore` (one fingerprint per line) or a repo-local `.gitleaks.toml` allowlist, commit it, and re-run.
3. **Apply branch protection** — only after step 2 succeeds, run from `jclee941/.github`:
   ```
   go run ./scripts/cmd/branch-protection --repos=<this-repo>
   ```
   This registers `Gitleaks / scan` as a third required status check (alongside the two existing `pr-checks` contexts). Skipping step 2 will deadlock all subsequent PRs (including Dependabot) on a missing required check.


___

### **PR Type**
Enhancement


___

### **Description**
- 공통 인벤토리 저장소 분리 체크아웃 추가

- 설정 파일 경로를 인벤토리 디렉터리로 변경

- 워크플로우 실행 결과 조회 로직 간소화

- 실패 보고 형식 및 불필요 필드 제거


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Checkout jclee941/.github to .github-inventory"] --> B["Load .github-inventory/config/repos.yaml"]
  B --> C["Query workflow runs via gh CLI"]
  C --> D["Output simplified failure list"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>downstream-health-check.yml</strong><dd><code>하위 저장소 상태 확인 워크플로우 개선</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/downstream-health-check.yml

<ul><li><code>actions/checkout</code> 단계에 <code>repository: jclee941/.github</code> 및 <code>path: </code><br><code>.github-inventory</code> 추가<br> <li> <code>repos.yaml</code> 참조 경로를 <code>.github-inventory/config/repos.yaml</code>로 업데이트<br> <li> <code>gh run list</code> 결과 파싱 로직 간소화 및 미사용 필드(<code>headBranch</code>, <code>url</code>, <code>createdAt</code>) 제거<br> <li> 실패 보고 형식을 Markdown 테이블에서 간결한 텍스트 목록으로 변경</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/hycu_fsds/pull/60/files#diff-8dccb43dc9251b3da63d521bb94bba9e6a89e3ebf562bd8459673cfbc0f17a5f">+9/-12</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

