### PR TITLE
chore: sync automation workflows, dependabot, and templates

### DIFF
--- a/.github/workflows/bot-auto-fix.yml
+++ b/.github/workflows/bot-auto-fix.yml
@@ -1,0 +1,82 @@
+name: Bot Auto-Fix
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    paths:
+      - '.github/**'
+      - 'scripts/**'
+      - '.ls-lint.yml'
+      - 'docs/**'
+
+permissions:
+  contents: write
+  pull-requests: read
+
+concurrency:
+  group: bot-auto-fix-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  auto-fix:
+    if: >
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.head.ref != github.event.repository.default_branch &&
+      github.actor != 'dependabot[bot]'
+    runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
+    timeout-minutes: 10
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.GH_PAT || github.token }}
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.21'
+
+      - name: Run naming validator with --fix
+        id: fix
+        run: |
+          echo "Running validate-naming --fix..."
+          cd scripts
+          go run ./cmd/validate-naming --fix || true
+          echo "Done"
+
+      - name: Check if fixes were applied
+        id: check
+        run: |
+          if git diff --quiet; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            echo "No auto-fixes needed"
+          else
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+            echo "Auto-fixes applied"
+            git diff --stat
+          fi
+
+      - name: Push fixes back to PR
+        if: steps.check.outputs.has_changes == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT || github.token }}
+          GITHUB_TOKEN: ${{ secrets.GH_PAT || github.token }}
+        run: |
+          BRANCH="${{ github.event.pull_request.head.ref }}"
+          DEFAULT_BRANCH="${{ github.event.repository.default_branch }}"
+
+          if [ -z "$BRANCH" ] || [ "$BRANCH" = "$DEFAULT_BRANCH" ]; then
+            echo "::error::Refusing to push to default branch"
+            exit 1
+          fi
+
+          git config user.email "bot@jclee.me"
+          git config user.name "github-bot"
+          git add -A
+          git commit -m "bot: auto-fix naming conventions [skip ci]"
+          git push origin "HEAD:${BRANCH}"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -27,6 +27,8 @@ jobs:
   dependabot:
     if: ${{ github.actor == 'dependabot[bot]' && github.event.pull_request.draft == false }}
     runs-on: ${{ github.event.repository.private && 'self-hosted' || 'ubuntu-latest' }}
+    timeout-minutes: 10
+    steps:
     steps:
       - name: Fetch Dependabot metadata
         id: meta

--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -19,5 +19,8 @@ permissions:
 jobs:
   docs-sync:
     if: github.event_name == 'push' || github.event_name == 'pull_request'
+    timeout-minutes: 15
+    uses: jclee941/.github/.github/workflows/reusable-docs-sync.yml@master
+    secrets: inherit
     uses: jclee941/.github/.github/workflows/reusable-docs-sync.yml@master
     secrets: inherit

--- a/.github/workflows/issue-management.yml
+++ b/.github/workflows/issue-management.yml
@@ -15,5 +15,8 @@ permissions:
 jobs:
   issue-management:
     if: github.event_name != 'push'
+    timeout-minutes: 15
+    uses: jclee941/.github/.github/workflows/reusable-issue-management.yml@master
+    secrets: inherit
     uses: jclee941/.github/.github/workflows/reusable-issue-management.yml@master
     secrets: inherit


### PR DESCRIPTION
### **User description**
## Summary

Sync standard automation from `jclee941/.github`:

- **PR checks** (size, title, branch name, description, large files, sensitive files) - 2 enforcing + 4 advisory contexts.
- **Auto-review** via cli_proxy on every non-draft PR (Dependabot PRs are reviewed by `dependabot-auto-merge.yml` instead).
- **Dependabot auto-merge** for patch + minor + github_actions updates; majors and unknown update-types are commented for manual review.
- **CodeQL** (Python SAST), **Gitleaks** (secret scanning), **actionlint** (workflow YAML linter).
- **`.github/dependabot.yml`** schedules weekly `github-actions` + `pip` ecosystem updates. (`pip` will warn 'no manifest found' on non-Python repos; safe to ignore until Python is added.)
- **`.github/CODEOWNERS`** + **`.github/PULL_REQUEST_TEMPLATE.md`** - per-repo files (org-level CODEOWNERS does NOT propagate).
- **`.github/ISSUE_TEMPLATE/`** — standardized bug reports, feature requests, and security vulnerability templates.
- **Issue management + docs sync** workflows.

Deployed by `scripts/deploy-to-repos.go` from `jclee941/.github`. See [AGENTS.md § GIT FLOW AUTOMATION](https://github.com/jclee941/.github/blob/master/AGENTS.md#git-flow-automation) for the inventory and policy.

## Rollout sequence (REQUIRED ORDER - do not skip)

1. **Merge this PR** — the new workflows (`gitleaks.yml`, `codeql.yml`, `actionlint.yml`) start running on subsequent PRs as **advisory** checks. They are NOT yet required.
2. **Confirm `Gitleaks / scan` is green** — open one trivial test PR (or wait for the next real PR) and verify the Gitleaks job passes. If the repo has historical leaks, `gitleaks` will fail. In that case add a `.gitleaksignore` (one fingerprint per line) or a repo-local `.gitleaks.toml` allowlist, commit it, and re-run.
3. **Apply branch protection** — only after step 2 succeeds, run from `jclee941/.github`:
   ```
   go run ./scripts/cmd/branch-protection --repos=<this-repo>
   ```
   This registers `Gitleaks / scan` as a third required status check (alongside the two existing `pr-checks` contexts). Skipping step 2 will deadlock all subsequent PRs (including Dependabot) on a missing required check.


___

### **PR Type**
Other


___

### **Description**
- `bot-auto-fix.yml` 워크플로우 신규 추가

- 네이밍 컨벤션 자동 검증 및 수정 적용

- `dependabot-auto-merge`, `docs-sync`, `issue-management`에 `timeout-minutes` 추가


___

### Diagram Walkthrough


```mermaid
flowchart LR
  PRTrigger["PR opened / synchronize"] -- "triggers" --> BotAutoFix["bot-auto-fix.yml"]
  BotAutoFix -- "runs" --> Naming["validate-naming --fix"]
  Naming -- "pushes fixes" --> PushFixes["Push fixes to PR branch"]
  ExistingJobs["Existing workflows"] -- "adds" --> Timeout["timeout-minutes 설정"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bot-auto-fix.yml`</strong><dd><code>Bot Auto-Fix 워크플로우 신규 추가</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

`.github/workflows/bot-auto-fix.yml`

<ul><li><code>.github/**</code>, <code>scripts/**</code>, <code>docs/**</code>, <code>.ls-lint.yml</code> 경로 변경 시 트리거<br> <li> Go 기반 <code>validate-naming --fix</code> 실행 후 수정사항 자동 푸시<br> <li> Dependabot PR, Draft PR, 기본 브랜치 제외 및 동시성 제어 적용<br> <li> <code>contents: write</code> 권한으로 Bot 계정이 커밋 작성</ul>


</details>


  </td>
  <td><a href=""></a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dependabot-auto-merge.yml`</strong><dd><code>Dependabot 자동 병합 타임아웃 설정</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

`.github/workflows/dependabot-auto-merge.yml`

- `timeout-minutes: 10` 추가로 작업 시간 제한 설정


</details>


  </td>
  <td><a href=""></a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>docs-sync.yml`</strong><dd><code>Docs Sync 워크플로우 타임아웃 및 재사용 구조 추가</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

`.github/workflows/docs-sync.yml`

<ul><li><code>timeout-minutes: 15</code> 추가<br> <li> <code>jclee941/.github</code> 재사용 워크플로우 참조 및 <code>secrets: inherit</code> 명시</ul>


</details>


  </td>
  <td><a href=""></a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>issue-management.yml`</strong><dd><code>Issue Management 워크플로우 타임아웃 및 재사용 구조 추가</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

`.github/workflows/issue-management.yml`

<ul><li><code>timeout-minutes: 15</code> 추가<br> <li> <code>jclee941/.github</code> 재사용 워크플로우 참조 및 <code>secrets: inherit</code> 명시</ul>


</details>


  </td>
  <td><a href=""></a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

