### PR TITLE
chore: sync automation workflows, dependabot, and templates

### DIFF
--- a/.github/workflows/21_docs-sync.yml
+++ b/.github/workflows/21_docs-sync.yml
@@ -24,4 +24,6 @@ jobs:
   docs-sync:
     if: github.event_name == 'push' || github.event_name == 'pull_request'
     uses: jclee941/.github/.github/workflows/42_reusable-docs-sync.yml@master
+    with:
+      is_pull_request: ${{ github.event_name == 'pull_request' }}
     secrets: inherit

--- a/.github/workflows/42_reusable-docs-sync.yml
+++ b/.github/workflows/42_reusable-docs-sync.yml
@@ -1,6 +1,16 @@
 name: Reusable Documentation Sync
 on:
   workflow_call:
+    inputs:
+      is_pull_request:
+        description: >-
+          Whether the calling workflow was triggered by a pull_request event.
+          Reusable workflows run with github.event_name == 'workflow_call',
+          so the caller must forward its own event via this input; otherwise
+          PR-only jobs would silently skip in downstream repos.
+        required: false
+        default: false
+        type: boolean
   workflow_dispatch:
 
 permissions:
@@ -14,7 +24,7 @@ concurrency:
 
 jobs:
   link-check:
-    if: github.event_name == 'pull_request'
+    if: ${{ inputs.is_pull_request }}
     runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
     timeout-minutes: 10
     steps:
@@ -61,8 +71,55 @@ jobs:
               labels: ['documentation', 'bot', 'broken-links']
             });
 
+  private-ip-check:
+    # Detect hardcoded RFC 1918 private IPs in Markdown docs. Runs against
+    # downstream repos too: they call this reusable workflow via the central
+    # `@master` reference, so edits here propagate without re-deploy. The
+    # detector script is pulled from jclee941/.github so downstream repos need
+    # not vendor it.
+    if: ${{ inputs.is_pull_request }}
+    runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
+    timeout-minutes: 10
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
+
+      - name: Checkout PR
+        uses: actions/checkout@v6
+        with:
+          path: pr
+
+      - name: Checkout detector script (from jclee941/.github)
+        uses: actions/checkout@v6
+        with:
+          repository: jclee941/.github
+          ref: master
+          path: tooling
+          sparse-checkout: |
+            scripts/check_private_ips.py
+          sparse-checkout-cone-mode: false
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Scan Markdown for hardcoded private IPs
+        run: |
+          set -eu
+          python tooling/scripts/check_private_ips.py pr \
+            2> ip-report.txt || EXIT=$?
+          cat ip-report.txt || true
+          if [ "${EXIT:-0}" -ne 0 ]; then
+            echo "::error::Hardcoded private IP(s) found in Markdown docs. See log above."
+            exit 1
+          fi
+
+
   markdown-lint:
-    if: github.event_name == 'pull_request'
+    if: ${{ inputs.is_pull_request }}
     runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
     timeout-minutes: 10
     steps:
@@ -97,7 +154,7 @@ jobs:
   readme-sync-check:
     runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
     timeout-minutes: 10
-    if: github.event_name == 'pull_request'
+    if: ${{ inputs.is_pull_request }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@v2
@@ -158,7 +215,7 @@ jobs:
   api-docs-check:
     runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
     timeout-minutes: 10
-    if: github.event_name == 'pull_request'
+    if: ${{ inputs.is_pull_request }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@v2


### PR DESCRIPTION
### **User description**
## Summary

Sync standard automation from `jclee941/.github`:

- **PR checks** (size, title, branch name, description, large files, sensitive files) - 2 enforcing + 4 advisory contexts.
- **Auto-review** via cli_proxy on every non-draft PR (Dependabot PRs are reviewed by `12_dependabot-auto-merge.yml` instead).
- **Dependabot auto-merge** for patch + minor + github_actions updates; majors and unknown update-types are commented for manual review.
- **CodeQL** (Python SAST), **Gitleaks** (secret scanning), **actionlint** (workflow YAML linter).
- **`.github/dependabot.yml`** schedules weekly `github-actions` + `pip` ecosystem updates. (`pip` will warn 'no manifest found' on non-Python repos; safe to ignore until Python is added.)
- **`.github/CODEOWNERS`** + **`.github/PULL_REQUEST_TEMPLATE.md`** - per-repo files (org-level CODEOWNERS does NOT propagate).
- **`.github/ISSUE_TEMPLATE/`** — standardized bug reports, feature requests, and security vulnerability templates.
- **Issue management + docs sync** workflows — markdown lint, link check, README sync validation, API docs check.
- **README generator** (`20_readme-gen.yml`) — auto-generates README.md via CLIProxyAPI (minimax-m2.7 → gpt-5.5 fallback).
- **Template sync** (`template-sync.yml`) — deploys standard `README.md`, `CONTRIBUTING.md`, `LICENSE` templates.

Deployed by `scripts/deploy-to-repos.go` from `jclee941/.github`. See [AGENTS.md § GIT FLOW AUTOMATION](https://github.com/jclee941/.github/blob/master/AGENTS.md#git-flow-automation) for the inventory and policy.

## Rollout sequence (REQUIRED ORDER - do not skip)

1. **Merge this PR** — the new workflows (`05_gitleaks.yml`, `06_codeql.yml`, `04_actionlint.yml`) start running on subsequent PRs as **advisory** checks. They are NOT yet required.
2. **Confirm `Gitleaks / scan` is green** — open one trivial test PR (or wait for the next real PR) and verify the Gitleaks job passes. If the repo has historical leaks, `gitleaks` will fail. In that case add a `.gitleaksignore` (one fingerprint per line) or a repo-local `.gitleaks.toml` allowlist, commit it, and re-run.
3. **Apply branch protection** — only after step 2 succeeds, run from `jclee941/.github`:
   ```
   go run ./scripts/cmd/branch-protection --repos=<this-repo>
   ```
   This registers `Gitleaks / scan` as a third required status check (alongside the two existing `pr-checks` contexts). Skipping step 2 will deadlock all subsequent PRs (including Dependabot) on a missing required check.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- `42_reusable-docs-sync.yml` PR 조건 버그 수정

- `is_pull_request` 입력 파라미터 신규 추가

- `private-ip-check` 작업 및 사설 IP 탐지 도입

- 다운스트림 중앙 스크립트 자동 연동 및 적용


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["21_docs-sync.yml"] -- "is_pull_request 입력 전달" --> B["42_reusable-docs-sync.yml"]
  B -- "기존 PR 조건 버그 수정" --> C["link-check, markdown-lint, readme-sync-check, api-docs-check"]
  B -- "신규 private-ip-check 작업 실행" --> D["Markdown 문서 사설 IP 탐지"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>21_docs-sync.yml`</strong><dd><code>Reusable 워크플로우에 `is_pull_request` 입력 전달 추가</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

`.github/workflows/21_docs-sync.yml`

<ul><li><code>docs-sync</code> 작업 호출 시 <code>is_pull_request</code> 입력값 전달 추가<br> <li> 상위 워크플로우의 이벤트 타입을 재사용 워크플로우에 올바르게 전달<br> <li> 다운스트림 레포지토리에서 PR 조건이 정상 평가되도록 지원</ul>


</details>


  </td>
  <td><a href=""></a></td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>42_reusable-docs-sync.yml`</strong><dd><code>`is_pull_request` 입력 추가, PR 조건 버그 수정 및 사설 IP 탐지 도입</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

`.github/workflows/42_reusable-docs-sync.yml`

<ul><li><code>workflow_call</code>에 <code>is_pull_request</code> boolean 입력 파라미터 신규 추가<br> <li> <code>github.event_name</code> 대신 <code>inputs.is_pull_request</code>를 사용하도록 조건식 버그 수정<br> <li> <code>private-ip-check</code> 작업 추가: <code>jclee941/.github</code>의 Python 스크립트로 Markdown 내 사설 <br>IP 탐지<br> <li> <code>link-check</code>, <code>markdown-lint</code>, <code>readme-sync-check</code>, <code>api-docs-check</code> 조건식 일괄 수정</ul>


</details>


  </td>
  <td><a href=""></a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

