### PR TITLE
chore: sync automation workflows, dependabot, and templates

### DIFF
--- a/.github/workflows/42_reusable-docs-sync.yml
+++ b/.github/workflows/42_reusable-docs-sync.yml
@@ -45,6 +45,7 @@ jobs:
             --skip-missing
             --exclude-path 'docs/pr-agent-upstream-README\.md'
             --exclude '\.\./\.\./security/advisories/new'
+            --exclude 'cliproxy\.jclee\.me'
             --no-progress
             README.md
             docs/
@@ -56,20 +57,44 @@ jobs:
         uses: actions/github-script@v9
         with:
           script: |
-            const body = `## 🚨 문서 링크 깨짐 감지\n\n` +
-              `Markdown 파일의 링크 점검 중 깨진 링크가 발견되었습니다.\n\n` +
+            // Stable title (no per-run date) so we can dedupe. Spamming a new
+            // issue every failed run floods the tracker; instead comment on
+            // the existing open broken-links issue if one exists.
+            const title = '[BOT] \uba38\uc11c \ub9c1\ud06c \uae68\uc9d0 \uac10\uc9c0';
+            const body = `## \ud83d\udea8 \ubb38\uc11c \ub9c1\ud06c \uae68\uc9d0 \uac10\uc9c0\n\n` +
+              `Markdown \ud30c\uc77c\uc758 \ub9c1\ud06c \uc810\uac80 \uc911 \uae68\uc9c4 \ub9c1\ud06c\uac00 \ubc1c\uacac\ub418\uc5c8\uc2b5\ub2c8\ub2e4.\n\n` +
               `- Workflow: ${{ github.workflow }}\n` +
               `- Commit: ${{ github.sha }}\n` +
-              `- Branch: ${{ github.ref }}\n\n` +
-              `> 자동 생성됨 (Documentation Sync Workflow)`;
-            
-            await github.rest.issues.create({
+              `- Branch: ${{ github.ref }}\n` +
+              `- Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\n\n` +
+              `> \uc790\ub3d9 \uc0dd\uc131\ub428 (Documentation Sync Workflow)`;
+
+            const existing = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title: `[BOT] 문서 링크 깨짐 감지 (${new Date().toISOString().split('T')[0]})`,
-              body: body,
-              labels: ['documentation', 'bot', 'broken-links']
+              state: 'open',
+              labels: 'broken-links',
+              per_page: 100,
             });
+            const match = existing.data.find(i => i.title === title);
+            if (match) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: match.number,
+                body: body,
+              });
+              core.notice(`Recorded broken-link recurrence on existing issue #${match.number}`);
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: title,
+                body: body,
+                labels: ['documentation', 'bot', 'broken-links'],
+              });
+              core.notice('Created new broken-links issue');
+            }
 
   private-ip-check:
     # Detect hardcoded RFC 1918 private IPs in Markdown docs. Runs against


### PR DESCRIPTION
### **User description**
## Summary

Sync standard automation from `jclee941/.github`:

- **PR checks** (size, title, branch name, description, large files, sensitive files) - 2 enforcing + 4 advisory contexts.
- **Auto-review** via cli_proxy on every non-draft PR (Dependabot PRs are reviewed by `12_dependabot-auto-merge.yml` instead).
- **Dependabot auto-merge** for patch + minor + github_actions updates; majors and unknown update-types are commented for manual review.
- **CodeQL** (Python SAST), **Gitleaks** (secret scanning), **actionlint** (workflow YAML linter).
- **`.github/dependabot.yml`** schedules weekly `github-actions` + `pip` ecosystem updates. (`pip` will warn 'no manifest found' on non-Python repos; safe to ignore until Python is added.)
- **`.github/CODEOWNERS`** + **`.github/PULL_REQUEST_TEMPLATE.md`** - per-repo files (org-level CODEOWNERS does NOT propagate).
- **`.github/ISSUE_TEMPLATE/`** — standardized bug reports, feature requests, and security vulnerability templates.
- **Issue management + docs sync** workflows — markdown lint, link check, README sync validation, API docs check.
- **README generator** (`20_readme-gen.yml`) — auto-generates README.md via CLIProxyAPI (minimax-m2.7 → gpt-5.5 fallback).
- **Template sync** (`template-sync.yml`) — deploys standard `README.md`, `CONTRIBUTING.md`, `LICENSE` templates.

Deployed by `scripts/deploy-to-repos.go` from `jclee941/.github`. See [AGENTS.md § GIT FLOW AUTOMATION](https://github.com/jclee941/.github/blob/master/AGENTS.md#git-flow-automation) for the inventory and policy.

## Rollout sequence (REQUIRED ORDER - do not skip)

1. **Merge this PR** — the new workflows (`05_gitleaks.yml`, `06_codeql.yml`, `04_actionlint.yml`) start running on subsequent PRs as **advisory** checks. They are NOT yet required.
2. **Confirm `Gitleaks / scan` is green** — open one trivial test PR (or wait for the next real PR) and verify the Gitleaks job passes. If the repo has historical leaks, `gitleaks` will fail. In that case add a `.gitleaksignore` (one fingerprint per line) or a repo-local `.gitleaks.toml` allowlist, commit it, and re-run.
3. **Apply branch protection** — only after step 2 succeeds, run from `jclee941/.github`:
   ```
   go run ./scripts/cmd/branch-protection --repos=<this-repo>
   ```
   This registers `Gitleaks / scan` as a third required status check (alongside the two existing `pr-checks` contexts). Skipping step 2 will deadlock all subsequent PRs (including Dependabot) on a missing required check.


___

### **PR Type**
Enhancement


___

### **Description**
- 문서 워크플로우 링크 검사 및 이슈 개선

- `cliproxy.jclee.me` 도메인 링크 검사 제외 추가

- 깨진 링크 이슈 중복 생성 방지 로직 추가

- 이슈 본문에 실행 URL 및 알림 로깅 추가


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["링크 검사 실행"]
  B["깨진 링크 감지"]
  C["이슈 중복 확인"]
  D["기존 이슈에 코멘트 추가"]
  E["신규 이슈 생성"]
  A -- "cliproxy.jclee.me 제외" --> B
  B -- "실패 시" --> C
  C -- "기존 이슈 존재" --> D
  C -- "미존재" --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>42_reusable-docs-sync.yml</strong><dd><code>문서 동기화 워크플로우 링크 검사 및 이슈 관리 개선</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/42_reusable-docs-sync.yml

<ul><li>링크 검사기 인자에 <code>cliproxy.jclee.me</code> 도메인을 제외(<code>--exclude</code>)하는 옵션 추가<br> <li> 깨진 링크 발견 시 고정된 제목으로 열린 이슈 중복을 확인하고, 기존 이슈가 있으면 코멘트를 추가하고 없으면 신규 이슈를 <br>생성하도록 변경<br> <li> 이슈 본문에 workflow 실행 URL(<code>github.run_id</code>) 정보 추가<br> <li> <code>core.notice</code>를 활용한 처리 결과 알림 로깅 추가</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/hycu_fsds/pull/195/files#diff-64d7718cef016c48a850cd68a87492080f9f003163a2f08dca31ca9a1505946b">+34/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

