### PR TITLE
chore: sync automation workflows, dependabot, and templates

### DIFF
--- a/.github/workflows/45_reusable-gitleaks.yml
+++ b/.github/workflows/45_reusable-gitleaks.yml
@@ -71,10 +71,13 @@ jobs:
             echo "::error::gitleaks download failed or produced an empty file" >&2
             exit 1
           fi
-          mkdir -p "$HOME/.local/bin"
-          tar -xzf /tmp/gitleaks.tar.gz -C "$HOME/.local/bin" gitleaks
-          chmod +x "$HOME/.local/bin/gitleaks"
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          # The self-hosted runner may have HOME unset; under `set -u` a bare
+          # $HOME aborts the step. Use a default-expanded install dir.
+          BIN_DIR="${HOME:-/usr/local}/.local/bin"
+          mkdir -p "$BIN_DIR"
+          tar -xzf /tmp/gitleaks.tar.gz -C "$BIN_DIR" gitleaks
+          chmod +x "$BIN_DIR/gitleaks"
+          echo "$BIN_DIR" >> "$GITHUB_PATH"
 
       - name: Run gitleaks detect
         run: |


### PR DESCRIPTION
### **User description**
## Summary

Sync standard automation from `jclee941/.github`:

- **PR checks** (size, title, branch name, description, large files, sensitive files) - 2 enforcing + 4 advisory contexts.
- **Auto-review** via cli_proxy on every non-draft PR (Dependabot PRs are reviewed by `12_dependabot-auto-merge.yml` instead).
- **Dependabot auto-merge** for patch + minor + github_actions updates; majors and unknown update-types are commented for manual review.
- **CodeQL** (Python SAST), **Gitleaks** (secret scanning), **actionlint** (workflow YAML linter).
- **`.github/dependabot.yml`** schedules weekly `github-actions` + `pip` ecosystem updates. (`pip` will warn 'no manifest found' on non-Python repos; safe to ignore until Python is added.)
- **`.github/CODEOWNERS`** + **`.github/PULL_REQUEST_TEMPLATE.md`** - per-repo files (org-level CODEOWNERS does NOT propagate).
- **`.github/ISSUE_TEMPLATE/`** — standardized bug reports, feature requests, and security vulnerability templates.
- **Issue management + docs sync** workflows — markdown lint, link check, README sync validation, API docs check.
- **README generator** (`20_readme-gen.yml`) — auto-generates README.md via CLIProxyAPI (minimax-m2.7 → gpt-5.5 fallback).
- **Template sync** (`template-sync.yml`) — deploys standard `README.md`, `CONTRIBUTING.md`, `LICENSE` templates.

Deployed by `scripts/deploy-to-repos.go` from `jclee941/.github`. See [AGENTS.md § GIT FLOW AUTOMATION](https://github.com/jclee941/.github/blob/master/AGENTS.md#git-flow-automation) for the inventory and policy.

## Rollout sequence (REQUIRED ORDER - do not skip)

1. **Merge this PR** — the new workflows (`05_gitleaks.yml`, `06_codeql.yml`, `04_actionlint.yml`) start running on subsequent PRs as **advisory** checks. They are NOT yet required.
2. **Confirm `Gitleaks / scan` is green** — open one trivial test PR (or wait for the next real PR) and verify the Gitleaks job passes. If the repo has historical leaks, `gitleaks` will fail. In that case add a `.gitleaksignore` (one fingerprint per line) or a repo-local `.gitleaks.toml` allowlist, commit it, and re-run.
3. **Apply branch protection** — only after step 2 succeeds, run from `jclee941/.github`:
   ```
   go run ./scripts/cmd/branch-protection --repos=<this-repo>
   ```
   This registers `Gitleaks / scan` as a third required status check (alongside the two existing `pr-checks` contexts). Skipping step 2 will deadlock all subsequent PRs (including Dependabot) on a missing required check.


___

### **PR Type**
Bug fix


___

### **Description**
- `.github/workflows/45_reusable-gitleaks.yml`에서 `HOME` 환경변수가 설정되지 않은 자체 호스팅 runner에서 발생하는 오류 해결

- `${HOME:-/usr/local}/.local/bin` 형식으로 기본값을 제공하여 `set -u` 옵션 사용 시 스크립트 중지 문제 수정

- gitleaks 바이너리 설치 디렉토리를 동적으로 결정하도록 변경


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["gitleaks workflow"] --> B{"HOME variable set?"}
  B -->|No| C["BIN_DIR = /usr/local/.local/bin"]
  B -->|Yes| D["BIN_DIR = $HOME/.local/bin"]
  C --> E["Install gitleaks"]
  D --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>45_reusable-gitleaks.yml</strong><dd><code>Fix HOME unset handling for self-hosted runners</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/45_reusable-gitleaks.yml

<ul><li><code>HOME</code> 변수가 unset된 자체 호스팅 runner 환경 대응<br> <li> <code>mkdir</code>, <code>tar</code>, <code>chmod</code> 명령에서 사용할 <code>BIN_DIR</code> 변수에 기본값 <code>/usr/local</code> 할당<br> <li> <code>set -u</code>模式下 <code>$HOME</code> 참조 시 발생하던 오류 방지</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/hycu_fsds/pull/289/files#diff-b0c214cbba4f66a13fff736b9ecc79f46a529587bb37cb1ced1d6c7c60f062c7">+7/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

