### PR TITLE
chore: sync automation workflows, dependabot, and templates

### DIFF
--- a/.github/actions/setup-build-cache/action.yml
+++ b/.github/actions/setup-build-cache/action.yml
@@ -25,13 +25,32 @@ runs:
         nas_base="/mnt/nas-cache"
         local_base="${RUNNER_TEMP:-/tmp}/gha-cache"
 
-        # Prefer the NAS mount; degrade to a local path if it is missing or
-        # not writable so a broken mount never hard-fails the build.
-        if [ -d "$nas_base" ] && [ -w "$nas_base" ]; then
-          base="$nas_base"
+        # Prefer the NAS mount; self-heal its permissions if needed (a freshly
+        # provisioned NFS volume is root-owned, but the runner is non-root).
+        # Degrade to a local path only if the NAS mount is truly unusable, so a
+        # broken mount never hard-fails the build.
+        base="$local_base"
+        if [ -d "$nas_base" ]; then
+          probe="$nas_base/.write-probe.$$"
+          if (mkdir -p "$nas_base/$runner_slug" && touch "$probe") >/dev/null 2>&1; then
+            rm -f "$probe"
+            base="$nas_base"
+          elif command -v sudo >/dev/null 2>&1 && sudo -n true >/dev/null 2>&1; then
+            # Self-heal: claim the cache tree for the runner user once.
+            if sudo mkdir -p "$nas_base" \
+               && sudo chown "$(id -u):$(id -g)" "$nas_base" \
+               && sudo chmod 0775 "$nas_base" \
+               && touch "$probe" >/dev/null 2>&1; then
+              rm -f "$probe"
+              base="$nas_base"
+              echo "build cache: self-healed NAS mount permissions on $nas_base"
+            fi
+          fi
+        fi
+
+        if [ "$base" = "$nas_base" ]; then
           echo "build cache: using NAS mount $nas_base"
         else
-          base="$local_base"
           echo "::warning::NAS mount $nas_base unavailable/unwritable; falling back to $local_base"
         fi
 


### PR DESCRIPTION
### **User description**
## Summary

Sync standard automation from `jclee941/.github`:

- **PR checks** (size, title, branch name, description, large files, sensitive files) - 2 enforcing + 4 advisory contexts.
- **Auto-review** via cli_proxy on every non-draft PR (Dependabot PRs are reviewed by `12_dependabot-auto-merge.yml` instead).
- **Dependabot auto-merge** for patch + minor + github_actions updates; majors and unknown update-types are commented for manual review.
- **CodeQL** (Python SAST), **Gitleaks** (secret scanning), **actionlint** (workflow YAML linter).
- **`.github/dependabot.yml`** schedules weekly `github-actions` + `pip` ecosystem updates. (`pip` will warn 'no manifest found' on non-Python repos; safe to ignore until Python is added.)
- **`.github/CODEOWNERS`** + **`.github/PULL_REQUEST_TEMPLATE.md`** - per-repo files (org-level CODEOWNERS does NOT propagate).
- **`.github/ISSUE_TEMPLATE/`** — standardized bug reports, feature requests, and security vulnerability templates.
- **Issue management + docs sync** workflows — markdown lint, link check, README sync validation, API docs check.
- **README generator** (`20_readme-gen.yml`) — auto-generates README.md via CLIProxyAPI (minimax-m2.7 → gpt-5.5 fallback).
- **Template sync** (`template-sync.yml`) — deploys standard `README.md`, `CONTRIBUTING.md`, `LICENSE` templates.

Deployed by `scripts/deploy-to-repos.go` from `jclee941/.github`. See [AGENTS.md § GIT FLOW AUTOMATION](https://github.com/jclee941/.github/blob/master/AGENTS.md#git-flow-automation) for the inventory and policy.

## Rollout sequence (REQUIRED ORDER - do not skip)

1. **Merge this PR** — the new workflows (`05_gitleaks.yml`, `06_codeql.yml`, `04_actionlint.yml`) start running on subsequent PRs as **advisory** checks. They are NOT yet required.
2. **Confirm `Gitleaks / scan` is green** — open one trivial test PR (or wait for the next real PR) and verify the Gitleaks job passes. If the repo has historical leaks, `gitleaks` will fail. In that case add a `.gitleaksignore` (one fingerprint per line) or a repo-local `.gitleaks.toml` allowlist, commit it, and re-run.
3. **Apply branch protection** — only after step 2 succeeds, run from `jclee941/.github`:
   ```
   go run ./scripts/cmd/branch-protection --repos=<this-repo>
   ```
   This registers `Gitleaks / scan` as a third required status check (alongside the two existing `pr-checks` contexts). Skipping step 2 will deadlock all subsequent PRs (including Dependabot) on a missing required check.


___

### **PR Type**
Enhancement


___

### **Description**
- NAS 마운트 권한 자동 복구(self-heal) 기능 추가: 새로 프로비저닝된 NFS 볼륨이 root 소유인 경우에도 runner 사용자가 캐시를 사용 가능

- sudo 권한이 있는 환경에서 자동으로 소유권(chown) 및 권한(chmod 0775)을 수정하여 빌드 실패 방지

- 프로브 파일 방식으로 쓰기 가능성을 더 정확하게 확인하여 견고성 향상

- 로컬 폴백 경로보다 NAS 마운트를 우선적으로 사용하면서도 손상된 마운트가 빌드를 중단시키지 않도록 보호


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Check NAS mount<br>existence"] --> B{"Probe write<br>test"}
  B -->|Success| C["Use NAS mount<br>$nas_base"]
  B -->|Fail| D{"sudo<br>available?"}
  D -->|Yes| E["Self-heal permissions<br>chown + chmod"]
  E -->|Success| C
  D -->|No| F["Fallback to local<br>$local_base"]
  C --> G["Log: using NAS mount"]
  F --> H["Log: warning<br>fallback message"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>action.yml</strong><dd><code>NAS 마운트 권한 자동 복구 기능 추가</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/actions/setup-build-cache/action.yml

<ul><li>NFS 마운트 권한 자동 복구 로직 추가: root 소유 NFS 볼륨을 runner 사용자가 사용 가능하도록 sudo로 <br>chown/chmod 수행<br> <li> 프로브 파일(.write-probe) 생성 방식으로 쓰기 가능성 검증하여 견고성 강화<br> <li> sudo 사용 불가 시 로컬 폴백 경로로 자동 전환하는 보호 메커니즘 구현<br> <li> 성공 시 "self-healed NAS mount permissions" 메시지 로깅</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/hycu_fsds/pull/331/files#diff-e22dec1852d6dcbcb4a828b3ac0538fa7b31fc4cc637f5828e2111e763fba58c">+24/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

